### PR TITLE
Add Query Author By Last Name And Query Book By Title

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.0.0-M5</version>
+			<version>5.9.0</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/com/graphqljava/tutorial/bookDetails/mongoDB/repository/AuthorRepository.java
+++ b/src/main/java/com/graphqljava/tutorial/bookDetails/mongoDB/repository/AuthorRepository.java
@@ -2,7 +2,11 @@ package com.graphqljava.tutorial.bookDetails.mongoDB.repository;
 
 import com.graphqljava.tutorial.bookDetails.mongoDB.entity.Author;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface AuthorRepository extends MongoRepository<Author, String> {
-
+    List<Author> getAuthorByLastNameIsIgnoreCase(String lastname);
 }

--- a/src/main/java/com/graphqljava/tutorial/bookDetails/mongoDB/repository/BookRepository.java
+++ b/src/main/java/com/graphqljava/tutorial/bookDetails/mongoDB/repository/BookRepository.java
@@ -2,7 +2,11 @@ package com.graphqljava.tutorial.bookDetails.mongoDB.repository;
 
 import com.graphqljava.tutorial.bookDetails.mongoDB.entity.Book;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface BookRepository extends MongoRepository<Book, String> {
-
+    List<Book> getBookByTitleIsIgnoreCase(String title);
 }

--- a/src/main/java/com/graphqljava/tutorial/bookDetails/resolver/Query.java
+++ b/src/main/java/com/graphqljava/tutorial/bookDetails/resolver/Query.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.io.FileNotFoundException;
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -36,6 +37,15 @@ public class Query implements GraphQLQueryResolver {
         throw new GraphQLException("Could Not Find Provided Author With Id [" + id + "]");
     }
 
+    public Iterable<Author> findAuthorsByLastName(String lastName) throws GraphQLException {
+        List<Author> authors = authorRepository.getAuthorByLastNameIsIgnoreCase(lastName);
+
+        if(authors.isEmpty()) {
+            throw new GraphQLException("Could Not Find Author(s) With Name [" + lastName + "]");
+        }
+        return authors;
+    }
+
     public Iterable<Book> findAllBooks() {
         return bookRepository.findAll();
     }
@@ -47,6 +57,15 @@ public class Query implements GraphQLQueryResolver {
            return optionalBook.get();
        }
         throw new GraphQLException("Could Not Find Provided Author With Id [" + id + "]");
+    }
+
+    public Iterable<Book> findBooksByTitle(String title) throws GraphQLException {
+        List<Book> books = bookRepository.getBookByTitleIsIgnoreCase(title);
+
+        if(books.isEmpty()) {
+            throw new GraphQLException("Could Not Find Books(s) With Title [" + title + "]");
+        }
+        return books;
     }
 
     public long countAuthors() {

--- a/src/main/resources/graphql/author.graphqls
+++ b/src/main/resources/graphql/author.graphqls
@@ -9,6 +9,7 @@ type Author {
 type Query {
     findAllAuthors: [Author]!
     findAuthorById(id: ID!): Author!
+    findAuthorsByLastName(lastName: String!): [Author]
     countAuthors: Int!
 }
 

--- a/src/main/resources/graphql/book.graphqls
+++ b/src/main/resources/graphql/book.graphqls
@@ -8,6 +8,7 @@ type Book {
 extend type Query {
     findAllBooks: [Book]!
     findBookById(id: ID!): Book!
+    findBooksByTitle(title: String!): [Book]
     countBooks: Int!
 }
 

--- a/src/test/java/com/graphqljava/tutorial/bookDetails/GraphQLApiSpringTestApplicationTests.java
+++ b/src/test/java/com/graphqljava/tutorial/bookDetails/GraphQLApiSpringTestApplicationTests.java
@@ -1,9 +1,9 @@
 package com.graphqljava.tutorial.bookDetails;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 
-@SpringBootTest
+@TestConfiguration
 class GraphQLApiSpringTestApplicationTests {
 
 	@Test


### PR DESCRIPTION
### Overview

Added Logic To Allow Books To Be Queried By Their Title And Auhtos To Be Queried By Their Last Name.

### Changes

- Added Logic Within `AuthorRepository` To Handle Retrieving Author Objects Based On Matching Last Names.
- Added Logic Within `BookRepository` To Handle Retrieving Book Objects Based On Matching Titles.
- Added Logic In `Query` Handler To Return Found Author And Book Objects And Throw Exceptions If No Items Could Be Found.
- Updated Schema In `author.graphls` To Account For Querying Authors By Last Name When Sending Requests
- Updated Schema In `book.graphls` To Account For Querying Books By Title When Sending Requests

### Minor Additions/Bug Fixes

- Resolve Auto Spring Test Handlers In `GraphQLApiSpringTestApplicationTests.java`.
- Updated Jupiter Tests Dependency In `pom.xml`.