### PR TITLE
Update Docker Deployments And Documentation

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,8 +1,10 @@
-name: CI
+name: Build And Push Docker Image To DockerHub
 
 on:
   push:
     branches: [ "main" ]
+  tags:
+    - "v*"
 
 jobs:
 
@@ -30,4 +32,5 @@ jobs:
       with:
         context: .
         push: true
-        tags: jrd3064/graphql-mongodb:latest, jrd3064/graphql-mongodb:${{github.run_id}}
+        tag_with_refs: true
+        additional_tags: latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM openjdk:19-jdk-alpine
+VOLUME /tmp
 MAINTAINER Ryan Derr
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 3. Create a database called `BookStore` with two containers called `book` and `author`.
 4. Run `mvn clean install` (Requires Maven Setup) to install and compile all necessary packages and files.
 5. Run the GraphQLAPISpringTestApplication and set active profile(s) to `local`.
-6. Request can be sent and checked with [Insomnia](https://insomnia.rest/) with samples in the `SampleInsomniaRequests/` directory that can be imported into insomnia. 
+6. Request can be sent and checked with [Insomnia](https://insomnia.rest/) with samples in the `SampleInsomniaRequests/` directory that can be imported into insomnia.
 7. You can now query and mutate the database with this microservice on http://localhost:8080/graphql
 
 
 
-## Create And Run GraphQL Microservice and MongoDB On Docker
+## Create And Run GraphQL Microservice and MongoDB On Docker Locally
 1. Install docker desktop through the DockerHub [here](https://www.docker.com/products/docker-desktop/).
-2. Install/Run the mongodb docker container existing on port 8082 (The MongoDB container runs on port 27017 for any containerized applications run locally.)
-`docker run --name mongodb -d -p 8082:27017 mongo`
-3. Build Docker Image for the microservice ` docker build -t graphql-mongo .`
-4. Within Docker Desktop run the graphql-mongo image and specify the host port as port `8080` when running the container. 
-
-**Note:** If the microservice container cannot connect to the mongodb container you may need to check and change the host for the application-docker profile with the dockerized ip of MongoDB using the command `docker inspect mongodb | grep IPAddress`.
+2. Create a docker network so services can easily communicate with one another with command: `docker network create {NETWORK_NAME}`
+3. Install/Run the mongodb docker container existing on port 8082 (The MongoDB container runs on port 27017 for any containerized applications)
+   `docker run --name {MONGO_CONTAINER_NAME} -d -p 8082:27017 --network {NETWORK_NAME} mongo`
+4. Build Docker Image for the microservice ` docker build -t {MICROSERVICE_IMAGE_NAME} .`
+5. Connect mongo container to a  network that the microservice will run on with the command `docker network connect {NETWORK_NAME} {MONGO_CONTAINER_NAME}`
+6. Run the docker image for the graphql microservice with the command `docker run -d -p 8080:8080 --network {NETWORK_NAME} -e MONGODB_HOST={MONGO_CONTAINER_NAME} --name {MICROSERVICE_CONTAINER_NAME} {MICROSERVICE_IMAGE_NAME}`

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -1,7 +1,7 @@
 spring:
   data:
     mongodb:
-      host: "172.17.0.2"
+      host: ${MONGODB_HOST:localhost}
       port: 27017
       database: "BookStore"
 graphql:


### PR DESCRIPTION
### Overview
Updated to Docker Git Workflow And Additionally Updated The Documentation On How To Run The Service With MongoDB Locally On Docker. 

### Major Changes

- Updated the `docker-image.yml` for deploying docker images to docker hub. This will now tag each of the images with the latest and the version number assigned from git. 
- Updated `README.md` to have more up-to-date instructions on how to deploy MongoDB and the GraphQL Microservice locally within docker. 
- Updated `application-docker.yml` to now have the host which MongoDB runs on to be set to an environment variable set during the run of docker, or by default to `localhost` if no environment variable `MONGODB_HOST` was set. 